### PR TITLE
Use synchronous rtlcss to avoid race conditions

### DIFF
--- a/lib/langOptimizer.js
+++ b/lib/langOptimizer.js
@@ -62,9 +62,10 @@ LangOptimizer.prototype.resultHandler = function(result, filter, relativePath, a
     }
 
     if (options.rtlLangs && options.rtlLangs.indexOf(lang) >= 0) {
-      rtlcss(options.rtlOptions).process(langCSS).then(function(result) {
-        addOutputFile(result.css, langFilename);
-      });
+      addOutputFile(
+        rtlcss.process(langCSS, options.rtlOptions),
+        langFilename
+      );
     } else {
       addOutputFile(langCSS, langFilename);
     }


### PR DESCRIPTION
Use a synchronous version of the `rtlcss` transform since we aren't using source maps anyway and only need the `css` as a string (which is what this returns).

This is to avoid weird race conditions where we invoke asynchronous code from within synchronous code.
