### PR TITLE
Bump rtlcss to next major, bump lang-optimizer's version to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "broccoli-css-lang-optimizer",
   "description": "Extract Lang-specific CSS rulesets to lang-specific files.",
-  "version": "1.1.4",
+  "version": "2.0.0",
   "author": "Chris Eppstein <chris@eppsteins.net>",
   "main": "lib/langOptimizer.js",
   "license": "Apache-2.0",
@@ -20,7 +20,7 @@
   "dependencies": {
     "broccoli-postcss-sourcemaps": "^2.2.0-sourcemaps.1",
     "postcss-lang-optimizer": "^1.3.1",
-    "rtlcss": "^1.7.3"
+    "rtlcss": "^2.0.4"
   },
   "devDependencies": {
     "broccoli": "^0.16.5",


### PR DESCRIPTION
rtlcss > 2.0.0 contains important control directives that give users control over rtl processing behavior.
