### PR TITLE
Avoid publishing 70MB of unneeded assets

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+dist/
+tmp/
+bower_components/
+test/


### PR DESCRIPTION
Adds an .npmignore to ignore directories unneeded by published builds.

```
du -sh node_modules/postcss-lang-optimizer/*
4.0K	node_modules/postcss-lang-optimizer/CHANGELOG.md
4.0K	node_modules/postcss-lang-optimizer/Gruntfile.js
4.0K	node_modules/postcss-lang-optimizer/LICENSE
4.0K	node_modules/postcss-lang-optimizer/README.md
 33M	node_modules/postcss-lang-optimizer/dist
4.0K	node_modules/postcss-lang-optimizer/gulpfile.js
8.0K	node_modules/postcss-lang-optimizer/lib
4.0K	node_modules/postcss-lang-optimizer/package.json
956K	node_modules/postcss-lang-optimizer/test
 36M	node_modules/postcss-lang-optimizer/tmp
```