### PR TITLE
Restrict language rulesets extraction to languages in options

### DIFF
--- a/lib/langOptimizer.js
+++ b/lib/langOptimizer.js
@@ -37,8 +37,16 @@ LangOptimizer.prototype.constructor = LangOptimizer;
 
 LangOptimizer.prototype.resultHandler = function(result, filter, relativePath, addOutputFile) {
   var options = this.optimizerOpts;
-  var langResults = langOptimizer.extractAll(result);
-  var langs = options.langs ? options.langs : Object.keys(langResults);
+  var languagesIdentifiedForExtraction = {};
+  result.messages.forEach(function(result) {
+    var language = result.language;
+    if (language) {
+      languagesIdentifiedForExtraction[language] = language;
+    }
+  });
+
+  var langs = options.langs ? options.langs : Object.keys(languagesIdentifiedForExtraction);
+
   if (typeof langs === "function") {
     langs = langs();
   }
@@ -49,16 +57,20 @@ LangOptimizer.prototype.resultHandler = function(result, filter, relativePath, a
     } else {
       langFilename = relativePath.replace(".css", "_" + lang + ".css");
     }
+
+    var langResult;
+    if (languagesIdentifiedForExtraction[lang]) {
+      langResult = langOptimizer.extract(result, lang);
+    }
+
     if (options.includeBaseFile || typeof options.includeBaseFile === "undefined") {
-      if (langResults[lang]) {
-        langCSS = result.css + "\n" + langResults[lang] + "\n";
+      if (langResult) {
+        langCSS = result.css + "\n" + langResult + "\n";
       } else {
         langCSS = result.css;
       }
-    } else {
-      if (langResults[lang]) {
-        langCSS = langResults[lang] + "\n";
-      }
+    } else if (langResult) {
+      langCSS = langResult + "\n";
     }
 
     if (options.rtlLangs && options.rtlLangs.indexOf(lang) >= 0) {

--- a/test/test_langOptimizer.js
+++ b/test/test_langOptimizer.js
@@ -71,13 +71,13 @@ describe("LangOptimizer", function () {
   });
 
   it("can be instantiated by function call", function (done) {
-    var optimizer = LangOptimizer(fixtureSourceDir("basicProject"));
+    var optimizer = LangOptimizer(fixtureSourceDir("basicProject")); // eslint-disable-line new-cap
     assert(optimizer instanceof LangOptimizer);
     done();
   });
 
   it("splits css up by languages", function (done) {
-    var optimizer = LangOptimizer(fixtureSourceDir("basicProject"), {includeBaseFile: false});
+    var optimizer = new LangOptimizer(fixtureSourceDir("basicProject"), {includeBaseFile: false});
     var builder = new broccoli.Builder(optimizer);
 
     build(builder)
@@ -89,7 +89,7 @@ describe("LangOptimizer", function () {
   });
 
   it("includes the base file by default", function (done) {
-    var optimizer = LangOptimizer(fixtureSourceDir("includesBaseFile"));
+    var optimizer = new LangOptimizer(fixtureSourceDir("includesBaseFile"));
     var builder = new broccoli.Builder(optimizer);
 
     build(builder)
@@ -101,7 +101,7 @@ describe("LangOptimizer", function () {
   });
 
   it("allows custom filenames", function (done) {
-    var optimizer = LangOptimizer(fixtureSourceDir("customFilenames"), {
+    var optimizer = new LangOptimizer(fixtureSourceDir("customFilenames"), {
       includeBaseFile: false,
       filenameForLang: function(baseFilename, lang) {
          return baseFilename.replace(".css", "-" + lang + ".css");
@@ -118,7 +118,7 @@ describe("LangOptimizer", function () {
   });
 
   it("allows specified langs", function (done) {
-    var optimizer = LangOptimizer(fixtureSourceDir("specifiedLangs"), {
+    var optimizer = new LangOptimizer(fixtureSourceDir("specifiedLangs"), {
       langs: ["en", "zh"]
     });
     var builder = new broccoli.Builder(optimizer);
@@ -132,7 +132,7 @@ describe("LangOptimizer", function () {
   });
 
   it("flips rtl langs", function (done) {
-    var optimizer = LangOptimizer(fixtureSourceDir("rtlLangs"), {
+    var optimizer = new LangOptimizer(fixtureSourceDir("rtlLangs"), {
       rtlLangs: ["ar"]
     });
     var builder = new broccoli.Builder(optimizer);


### PR DESCRIPTION
At the moment while handling the results from postcss (resultHandler) we extract all the rulesets for all the languages even when they will not be used (`langOptimizer.extractAll(result)`)

There can be cases in which the user does not intent to use those ruleset extractions because the languages that require the extract are not part of the options (`options.langs`). 

We can skip this work and only extract the rulesets when we intent to use them. 